### PR TITLE
fix(docs): update extension for jsx code snippets file

### DIFF
--- a/docs/frontend-system/architecture/07-routes.md
+++ b/docs/frontend-system/architecture/07-routes.md
@@ -359,7 +359,7 @@ export const detailsSubRouteRef = createSubRouteRef({
 
 Using subroutes in a page extension is as simple as this:
 
-```tsx title="plugins/catalog/src/components/IndexPage.ts"
+```tsx title="plugins/catalog/src/components/IndexPage.tsx"
 import React from 'react';
 import { Routes, Route, useLocation } from 'react-router-dom';
 import { useRouteRef } from '@backstage/frontend-plugin-api';
@@ -402,7 +402,7 @@ export const IndexPage = () => {
 
 This is how you can get the parameters of a sub route URL:
 
-```tsx title="plugins/catalog/src/components/DetailsPage.ts"
+```tsx title="plugins/catalog/src/components/DetailsPage.tsx"
 import React from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -426,7 +426,7 @@ export const DetailsPage = () => {
 
 Finally, see how a plugin can provide subroutes:
 
-```tsx title="plugins/catalog/src/plugin.ts"
+```tsx title="plugins/catalog/src/plugin.tsx"
 import React from 'react';
 import {
   createPlugin,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

On [Sub Route References](https://backstage.io/docs/frontend-system/architecture/routes#sub-route-references) docs some code snippets are using `.ts` extension instead of `.tsx`. This is incorrect because those code snippets are using JSX with TypeScript. If anyone try to copy and past the snippet inside an IDE it will throw an error.

E.g:
![image](https://github.com/CaioAugustoo/backstage/assets/62035389/0fe9fd9e-bd94-4bd2-bd2d-9e03f586197f)


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

